### PR TITLE
Add ViewHelper example with autoClear fix

### DIFF
--- a/examples/webgl_viewhelper.html
+++ b/examples/webgl_viewhelper.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>three.js webgl - view helper</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+        <link type="text/css" rel="stylesheet" href="main.css">
+    </head>
+    <body>
+        <script type="importmap">
+            {
+                "imports": {
+                    "three": "../build/three.module.js",
+                    "three/addons/": "./jsm/"
+                }
+            }
+        </script>
+        <script type="module">
+            import * as THREE from 'three';
+            import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+            import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
+
+            let camera, scene, renderer, controls, viewHelper;
+
+            init();
+            animate();
+
+            function init() {
+
+                scene = new THREE.Scene();
+                scene.background = new THREE.Color( 0xaaaaaa );
+
+                renderer = new THREE.WebGLRenderer( { antialias: true } );
+                renderer.setPixelRatio( window.devicePixelRatio );
+                renderer.setSize( window.innerWidth, window.innerHeight );
+                document.body.appendChild( renderer.domElement );
+
+                camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.1, 100 );
+                camera.position.set( 2, 2, 4 );
+
+                controls = new OrbitControls( camera, renderer.domElement );
+                controls.enableDamping = true;
+
+                const ambient = new THREE.AmbientLight( 0x404040 );
+                scene.add( ambient );
+
+                const directional = new THREE.DirectionalLight( 0xffffff, 1 );
+                directional.position.set( 5, 10, 7.5 );
+                scene.add( directional );
+
+                const geometry = new THREE.BoxGeometry();
+                const material = new THREE.MeshStandardMaterial( { color: 0x6699ff } );
+                for ( let i = 0; i < 5; i ++ ) {
+                    const mesh = new THREE.Mesh( geometry, material );
+                    mesh.position.set( Math.random() * 3 - 1.5, Math.random() * 1.5, Math.random() * 3 - 1.5 );
+                    scene.add( mesh );
+                }
+
+                scene.add( new THREE.GridHelper( 5, 10 ) );
+
+                viewHelper = new ViewHelper( camera, renderer.domElement );
+
+                window.addEventListener( 'resize', onWindowResize );
+
+            }
+
+            function onWindowResize() {
+
+                camera.aspect = window.innerWidth / window.innerHeight;
+                camera.updateProjectionMatrix();
+
+                renderer.setSize( window.innerWidth, window.innerHeight );
+
+            }
+
+            function animate() {
+
+                requestAnimationFrame( animate );
+
+                controls.update();
+
+                renderer.render( scene, camera );
+
+                renderer.autoClear = false;
+                viewHelper.render( renderer );
+                renderer.autoClear = true;
+
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add new example `webgl_viewhelper.html`
- demonstrate using `ViewHelper` with a basic lit scene
- ensure overlay doesn't clear the main scene via `renderer.autoClear`

## Testing
- `npm test` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685897d6fa088330acf92f8e64869c22